### PR TITLE
Use only valid xbps configuration files

### DIFF
--- a/xbps-mini-builder
+++ b/xbps-mini-builder
@@ -31,10 +31,10 @@ fi
 
 # Does this system use another set of repos
 if [ -d /etc/xbps.d ] ; then
-    cat /etc/xbps.d/* > etc/repos-remote.conf
+    cat /etc/xbps.d/*.conf > etc/repos-remote.conf
     # If this platform is 64 bit, override those as well
     if [ "$(xbps-uhelper arch)" = "x86_64" ] ; then
-        cat /etc/xbps.d/* > etc/repos-remote-x86_64.conf
+        cat /etc/xbps.d/*.conf > etc/repos-remote-x86_64.conf
     fi
 
     # The bootstrap config is loaded seperately


### PR DESCRIPTION
Currently script collects all files from /etc/xbps.d/ while according to xbps.d(5) only files with .conf extension should be processed. Add extension to pattern when gathering config for the builde.